### PR TITLE
Add admin domain, services, controller and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,16 @@ frontend/.env
 .env
 *.env.local
 
+# Logs and local databases
+*.log
+*.db
+*.sqlite
+
+# Root-level build outputs
+/target
+/build
+/node_modules
+
 # IDE
 .idea/
 .vscode/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -6,3 +6,7 @@ target
 *.iml
 mvnw
 mvnw.cmd
+.env
+.env.local
+.env.production
+.env.development

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -38,6 +38,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -63,6 +67,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/src/main/java/com/consultingplatform/admin/domain/ConsultantApprovalStatus.java
+++ b/backend/src/main/java/com/consultingplatform/admin/domain/ConsultantApprovalStatus.java
@@ -1,0 +1,7 @@
+package com.consultingplatform.admin.domain;
+
+public enum ConsultantApprovalStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/backend/src/main/java/com/consultingplatform/admin/domain/ConsultantRegistration.java
+++ b/backend/src/main/java/com/consultingplatform/admin/domain/ConsultantRegistration.java
@@ -1,0 +1,95 @@
+package com.consultingplatform.admin.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "consultant_registrations")
+public class ConsultantRegistration {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long consultantId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ConsultantApprovalStatus status;
+
+    @Column(nullable = true)
+    private String approvedByAdminId;
+
+    @Column(nullable = true)
+    private String decisionReason;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Column(nullable = true)
+    private Instant decidedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getConsultantId() {
+        return consultantId;
+    }
+
+    public void setConsultantId(Long consultantId) {
+        this.consultantId = consultantId;
+    }
+
+    public ConsultantApprovalStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ConsultantApprovalStatus status) {
+        this.status = status;
+    }
+
+    public String getApprovedByAdminId() {
+        return approvedByAdminId;
+    }
+
+    public void setApprovedByAdminId(String approvedByAdminId) {
+        this.approvedByAdminId = approvedByAdminId;
+    }
+
+    public String getDecisionReason() {
+        return decisionReason;
+    }
+
+    public void setDecisionReason(String decisionReason) {
+        this.decisionReason = decisionReason;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getDecidedAt() {
+        return decidedAt;
+    }
+
+    public void setDecidedAt(Instant decidedAt) {
+        this.decidedAt = decidedAt;
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/domain/SystemPolicy.java
+++ b/backend/src/main/java/com/consultingplatform/admin/domain/SystemPolicy.java
@@ -1,0 +1,70 @@
+package com.consultingplatform.admin.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "system_policies")
+public class SystemPolicy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String policyKey;
+
+    @Column(nullable = false, length = 4000)
+    private String policyValue;
+
+    @Column(nullable = false)
+    private String updatedByAdminId;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getPolicyKey() {
+        return policyKey;
+    }
+
+    public void setPolicyKey(String policyKey) {
+        this.policyKey = policyKey;
+    }
+
+    public String getPolicyValue() {
+        return policyValue;
+    }
+
+    public void setPolicyValue(String policyValue) {
+        this.policyValue = policyValue;
+    }
+
+    public String getUpdatedByAdminId() {
+        return updatedByAdminId;
+    }
+
+    public void setUpdatedByAdminId(String updatedByAdminId) {
+        this.updatedByAdminId = updatedByAdminId;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/repository/ConsultantRegistrationRepository.java
+++ b/backend/src/main/java/com/consultingplatform/admin/repository/ConsultantRegistrationRepository.java
@@ -1,0 +1,12 @@
+package com.consultingplatform.admin.repository;
+
+import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
+import com.consultingplatform.admin.domain.ConsultantRegistration;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConsultantRegistrationRepository extends JpaRepository<ConsultantRegistration, Long> {
+    Optional<ConsultantRegistration> findByConsultantId(Long consultantId);
+    List<ConsultantRegistration> findByStatus(ConsultantApprovalStatus status);
+}

--- a/backend/src/main/java/com/consultingplatform/admin/repository/SystemPolicyRepository.java
+++ b/backend/src/main/java/com/consultingplatform/admin/repository/SystemPolicyRepository.java
@@ -1,0 +1,9 @@
+package com.consultingplatform.admin.repository;
+
+import com.consultingplatform.admin.domain.SystemPolicy;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SystemPolicyRepository extends JpaRepository<SystemPolicy, Long> {
+    Optional<SystemPolicy> findByPolicyKey(String policyKey);
+}

--- a/backend/src/main/java/com/consultingplatform/admin/service/ConflictException.java
+++ b/backend/src/main/java/com/consultingplatform/admin/service/ConflictException.java
@@ -1,0 +1,7 @@
+package com.consultingplatform.admin.service;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/service/ConsultantApprovalService.java
+++ b/backend/src/main/java/com/consultingplatform/admin/service/ConsultantApprovalService.java
@@ -1,0 +1,8 @@
+package com.consultingplatform.admin.service;
+
+import com.consultingplatform.admin.web.dto.ConsultantApprovalRequestDto;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalResponseDto;
+
+public interface ConsultantApprovalService {
+    ConsultantApprovalResponseDto approveOrRejectConsultant(Long consultantId, ConsultantApprovalRequestDto request);
+}

--- a/backend/src/main/java/com/consultingplatform/admin/service/ConsultantApprovalServiceImpl.java
+++ b/backend/src/main/java/com/consultingplatform/admin/service/ConsultantApprovalServiceImpl.java
@@ -1,0 +1,48 @@
+package com.consultingplatform.admin.service;
+
+import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
+import com.consultingplatform.admin.domain.ConsultantRegistration;
+import com.consultingplatform.admin.repository.ConsultantRegistrationRepository;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalDecision;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalRequestDto;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalResponseDto;
+import java.time.Instant;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConsultantApprovalServiceImpl implements ConsultantApprovalService {
+
+    private final ConsultantRegistrationRepository repository;
+
+    public ConsultantApprovalServiceImpl(ConsultantRegistrationRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public ConsultantApprovalResponseDto approveOrRejectConsultant(Long consultantId, ConsultantApprovalRequestDto request) {
+        if (request == null || request.getDecision() == null) {
+            throw new IllegalArgumentException("decision is required");
+        }
+
+        ConsultantRegistration registration = repository.findByConsultantId(consultantId)
+            .orElseThrow(() -> new ResourceNotFoundException("Consultant registration not found"));
+
+        ConsultantApprovalStatus newStatus = request.getDecision() == ConsultantApprovalDecision.APPROVE
+            ? ConsultantApprovalStatus.APPROVED
+            : ConsultantApprovalStatus.REJECTED;
+
+        registration.setStatus(newStatus);
+        registration.setApprovedByAdminId(request.getAdminId());
+        registration.setDecisionReason(request.getReason());
+        registration.setDecidedAt(Instant.now());
+
+        ConsultantRegistration saved = repository.save(registration);
+
+        return new ConsultantApprovalResponseDto(
+            saved.getConsultantId(),
+            saved.getStatus(),
+            saved.getApprovedByAdminId(),
+            saved.getDecidedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/service/PolicyUpsertResult.java
+++ b/backend/src/main/java/com/consultingplatform/admin/service/PolicyUpsertResult.java
@@ -1,0 +1,21 @@
+package com.consultingplatform.admin.service;
+
+import com.consultingplatform.admin.web.dto.PolicyResponseDto;
+
+public class PolicyUpsertResult {
+    private final boolean created;
+    private final PolicyResponseDto response;
+
+    public PolicyUpsertResult(boolean created, PolicyResponseDto response) {
+        this.created = created;
+        this.response = response;
+    }
+
+    public boolean isCreated() {
+        return created;
+    }
+
+    public PolicyResponseDto getResponse() {
+        return response;
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/service/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/consultingplatform/admin/service/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.consultingplatform.admin.service;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/service/SystemPolicyService.java
+++ b/backend/src/main/java/com/consultingplatform/admin/service/SystemPolicyService.java
@@ -1,0 +1,7 @@
+package com.consultingplatform.admin.service;
+
+import com.consultingplatform.admin.web.dto.PolicyUpsertRequestDto;
+
+public interface SystemPolicyService {
+    PolicyUpsertResult upsertPolicy(String policyKey, PolicyUpsertRequestDto request);
+}

--- a/backend/src/main/java/com/consultingplatform/admin/service/SystemPolicyServiceImpl.java
+++ b/backend/src/main/java/com/consultingplatform/admin/service/SystemPolicyServiceImpl.java
@@ -1,0 +1,68 @@
+package com.consultingplatform.admin.service;
+
+import com.consultingplatform.admin.domain.SystemPolicy;
+import com.consultingplatform.admin.repository.SystemPolicyRepository;
+import com.consultingplatform.admin.web.dto.PolicyResponseDto;
+import com.consultingplatform.admin.web.dto.PolicyUpsertRequestDto;
+import java.time.Instant;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SystemPolicyServiceImpl implements SystemPolicyService {
+
+    private static final Set<String> ALLOWED_KEYS = Set.of(
+        "CANCELLATION_RULES",
+        "PRICING_STRATEGY",
+        "NOTIFICATION_SETTINGS",
+        "REFUND_POLICY"
+    );
+
+    private final SystemPolicyRepository repository;
+
+    public SystemPolicyServiceImpl(SystemPolicyRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public PolicyUpsertResult upsertPolicy(String policyKey, PolicyUpsertRequestDto request) {
+        if (isBlank(policyKey)) {
+            throw new IllegalArgumentException("policyKey is required");
+        }
+        if (request == null || isBlank(request.getAdminId())) {
+            throw new IllegalArgumentException("adminId is required");
+        }
+        if (isBlank(request.getPolicyValue())) {
+            throw new IllegalArgumentException("policyValue is required");
+        }
+
+        String adminId = request.getAdminId().trim();
+
+        String normalizedKey = policyKey.trim().toUpperCase();
+        if (!ALLOWED_KEYS.contains(normalizedKey)) {
+            throw new IllegalArgumentException("unsupported policyKey");
+        }
+
+        SystemPolicy policy = repository.findByPolicyKey(normalizedKey).orElseGet(SystemPolicy::new);
+        boolean created = policy.getId() == null;
+
+        policy.setPolicyKey(normalizedKey);
+        policy.setPolicyValue(request.getPolicyValue());
+        policy.setUpdatedByAdminId(adminId);
+        policy.setUpdatedAt(Instant.now());
+
+        SystemPolicy saved = repository.save(policy);
+        PolicyResponseDto response = new PolicyResponseDto(
+            saved.getPolicyKey(),
+            saved.getPolicyValue(),
+            saved.getUpdatedByAdminId(),
+            saved.getUpdatedAt()
+        );
+
+        return new PolicyUpsertResult(created, response);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/web/AdminController.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/AdminController.java
@@ -1,0 +1,65 @@
+package com.consultingplatform.admin.web;
+
+import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
+import com.consultingplatform.admin.domain.ConsultantRegistration;
+import com.consultingplatform.admin.repository.ConsultantRegistrationRepository;
+import com.consultingplatform.admin.service.ConsultantApprovalService;
+import com.consultingplatform.admin.service.PolicyUpsertResult;
+import com.consultingplatform.admin.service.SystemPolicyService;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalRequestDto;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalResponseDto;
+import com.consultingplatform.admin.web.dto.PolicyResponseDto;
+import com.consultingplatform.admin.web.dto.PolicyUpsertRequestDto;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final ConsultantApprovalService consultantApprovalService;
+    private final SystemPolicyService systemPolicyService;
+    private final ConsultantRegistrationRepository consultantRegistrationRepository;
+
+    public AdminController(
+        ConsultantApprovalService consultantApprovalService,
+        SystemPolicyService systemPolicyService,
+        ConsultantRegistrationRepository consultantRegistrationRepository
+    ) {
+        this.consultantApprovalService = consultantApprovalService;
+        this.systemPolicyService = systemPolicyService;
+        this.consultantRegistrationRepository = consultantRegistrationRepository;
+    }
+
+    @PostMapping("/consultants/{consultantId}/approval")
+    public ResponseEntity<ConsultantApprovalResponseDto> approveOrRejectConsultant(
+        @PathVariable Long consultantId,
+        @Valid @RequestBody ConsultantApprovalRequestDto request
+    ) {
+        return ResponseEntity.ok(consultantApprovalService.approveOrRejectConsultant(consultantId, request));
+    }
+
+    @GetMapping("/consultants/pending")
+    public ResponseEntity<List<ConsultantRegistration>> getPendingConsultantRegistrations() {
+        return ResponseEntity.ok(consultantRegistrationRepository.findByStatus(ConsultantApprovalStatus.PENDING));
+    }
+
+    @PutMapping("/policies/{policyKey}")
+    public ResponseEntity<PolicyResponseDto> upsertPolicy(
+        @PathVariable String policyKey,
+        @Valid @RequestBody PolicyUpsertRequestDto request
+    ) {
+        PolicyUpsertResult result = systemPolicyService.upsertPolicy(policyKey, request);
+        HttpStatus status = result.isCreated() ? HttpStatus.CREATED : HttpStatus.OK;
+        return ResponseEntity.status(status).body(result.getResponse());
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/web/ApiErrorResponse.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/ApiErrorResponse.java
@@ -1,0 +1,38 @@
+package com.consultingplatform.admin.web;
+
+import java.time.Instant;
+import java.util.Map;
+
+public class ApiErrorResponse {
+    private final String code;
+    private final String message;
+    private final Instant timestamp;
+    private final Map<String, String> details;
+
+    public ApiErrorResponse(String code, String message) {
+        this(code, message, null);
+    }
+
+    public ApiErrorResponse(String code, String message, Map<String, String> details) {
+        this.code = code;
+        this.message = message;
+        this.timestamp = Instant.now();
+        this.details = details;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package com.consultingplatform.admin.web;
+
+import com.consultingplatform.admin.service.ConflictException;
+import com.consultingplatform.admin.service.ResourceNotFoundException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiErrorResponse> handleBadRequest(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(new ApiErrorResponse("BAD_REQUEST", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidationErrors(MethodArgumentNotValidException ex) {
+        Map<String, String> details = new LinkedHashMap<>();
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            details.putIfAbsent(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        return ResponseEntity.badRequest().body(
+            new ApiErrorResponse("BAD_REQUEST", "Request validation failed", details)
+        );
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ApiErrorResponse("NOT_FOUND", ex.getMessage()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ApiErrorResponse> handleConflict(ConflictException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(new ApiErrorResponse("CONFLICT", ex.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/web/dto/ConsultantApprovalDecision.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/dto/ConsultantApprovalDecision.java
@@ -1,0 +1,6 @@
+package com.consultingplatform.admin.web.dto;
+
+public enum ConsultantApprovalDecision {
+    APPROVE,
+    REJECT
+}

--- a/backend/src/main/java/com/consultingplatform/admin/web/dto/ConsultantApprovalRequestDto.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/dto/ConsultantApprovalRequestDto.java
@@ -1,0 +1,38 @@
+package com.consultingplatform.admin.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class ConsultantApprovalRequestDto {
+    @NotBlank(message = "adminId is required")
+    private String adminId;
+
+    @NotNull(message = "decision is required")
+    private ConsultantApprovalDecision decision;
+
+    private String reason;
+
+    public String getAdminId() {
+        return adminId;
+    }
+
+    public void setAdminId(String adminId) {
+        this.adminId = adminId;
+    }
+
+    public ConsultantApprovalDecision getDecision() {
+        return decision;
+    }
+
+    public void setDecision(ConsultantApprovalDecision decision) {
+        this.decision = decision;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/web/dto/ConsultantApprovalResponseDto.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/dto/ConsultantApprovalResponseDto.java
@@ -1,0 +1,34 @@
+package com.consultingplatform.admin.web.dto;
+
+import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
+import java.time.Instant;
+
+public class ConsultantApprovalResponseDto {
+    private Long consultantId;
+    private ConsultantApprovalStatus newStatus;
+    private String approvedByAdminId;
+    private Instant decidedAt;
+
+    public ConsultantApprovalResponseDto(Long consultantId, ConsultantApprovalStatus newStatus, String approvedByAdminId, Instant decidedAt) {
+        this.consultantId = consultantId;
+        this.newStatus = newStatus;
+        this.approvedByAdminId = approvedByAdminId;
+        this.decidedAt = decidedAt;
+    }
+
+    public Long getConsultantId() {
+        return consultantId;
+    }
+
+    public ConsultantApprovalStatus getNewStatus() {
+        return newStatus;
+    }
+
+    public String getApprovedByAdminId() {
+        return approvedByAdminId;
+    }
+
+    public Instant getDecidedAt() {
+        return decidedAt;
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/web/dto/PolicyResponseDto.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/dto/PolicyResponseDto.java
@@ -1,0 +1,33 @@
+package com.consultingplatform.admin.web.dto;
+
+import java.time.Instant;
+
+public class PolicyResponseDto {
+    private String policyKey;
+    private String policyValue;
+    private String updatedByAdminId;
+    private Instant updatedAt;
+
+    public PolicyResponseDto(String policyKey, String policyValue, String updatedByAdminId, Instant updatedAt) {
+        this.policyKey = policyKey;
+        this.policyValue = policyValue;
+        this.updatedByAdminId = updatedByAdminId;
+        this.updatedAt = updatedAt;
+    }
+
+    public String getPolicyKey() {
+        return policyKey;
+    }
+
+    public String getPolicyValue() {
+        return policyValue;
+    }
+
+    public String getUpdatedByAdminId() {
+        return updatedByAdminId;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/admin/web/dto/PolicyUpsertRequestDto.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/dto/PolicyUpsertRequestDto.java
@@ -1,0 +1,27 @@
+package com.consultingplatform.admin.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class PolicyUpsertRequestDto {
+    @NotBlank(message = "adminId is required")
+    private String adminId;
+
+    @NotBlank(message = "policyValue is required")
+    private String policyValue;
+
+    public String getAdminId() {
+        return adminId;
+    }
+
+    public void setAdminId(String adminId) {
+        this.adminId = adminId;
+    }
+
+    public String getPolicyValue() {
+        return policyValue;
+    }
+
+    public void setPolicyValue(String policyValue) {
+        this.policyValue = policyValue;
+    }
+}

--- a/backend/src/test/java/com/consultingplatform/ConsultiingPlatformTests.java
+++ b/backend/src/test/java/com/consultingplatform/ConsultiingPlatformTests.java
@@ -2,8 +2,10 @@ package com.consultingplatform;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(classes = ConsultiingPlatform.class)
+@ActiveProfiles("test")
 class ConsultiingPlatformTests {
 
     @Test

--- a/backend/src/test/java/com/consultingplatform/admin/integration/AdminUc11Uc12IntegrationTest.java
+++ b/backend/src/test/java/com/consultingplatform/admin/integration/AdminUc11Uc12IntegrationTest.java
@@ -1,0 +1,149 @@
+package com.consultingplatform.admin.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.consultingplatform.ConsultiingPlatform;
+import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
+import com.consultingplatform.admin.domain.ConsultantRegistration;
+import com.consultingplatform.admin.repository.ConsultantRegistrationRepository;
+import com.consultingplatform.admin.repository.SystemPolicyRepository;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = ConsultiingPlatform.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminUc11Uc12IntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ConsultantRegistrationRepository consultantRegistrationRepository;
+
+    @Autowired
+    private SystemPolicyRepository systemPolicyRepository;
+
+    @BeforeEach
+    void setupData() {
+        systemPolicyRepository.deleteAll();
+        consultantRegistrationRepository.deleteAll();
+    }
+
+    @Test
+    void uc11_approveConsultant_success() throws Exception {
+        createPendingConsultant(3001L);
+
+        String body = "{\"adminId\":\"admin-1\",\"decision\":\"APPROVE\",\"reason\":\"verified\"}";
+
+        mockMvc.perform(post("/api/admin/consultants/3001/approval")
+                .contentType("application/json")
+                .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.consultantId").value(3001))
+            .andExpect(jsonPath("$.newStatus").value("APPROVED"));
+    }
+
+    @Test
+    void uc11_rejectConsultant_success() throws Exception {
+        createPendingConsultant(3002L);
+        String body = "{\"adminId\":\"admin-1\",\"decision\":\"REJECT\",\"reason\":\"incomplete profile\"}";
+
+        mockMvc.perform(post("/api/admin/consultants/3002/approval")
+                .contentType("application/json")
+                .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.consultantId").value(3002))
+            .andExpect(jsonPath("$.newStatus").value("REJECTED"));
+    }
+
+    @Test
+    void uc11_getPendingConsultants_returnsPendingList() throws Exception {
+        createPendingConsultant(3004L);
+
+        mockMvc.perform(get("/api/admin/consultants/pending"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].consultantId").value(3004))
+            .andExpect(jsonPath("$[0].status").value("PENDING"));
+    }
+
+    @Test
+    void uc11_missingAdminId_validationError() throws Exception {
+        createPendingConsultant(3003L);
+        String body = "{\"adminId\":\"\",\"decision\":\"REJECT\"}";
+
+        mockMvc.perform(post("/api/admin/consultants/3003/approval")
+                .contentType("application/json")
+                .content(body))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.details.adminId").value("adminId is required"));
+    }
+
+    @Test
+    void uc12_createPolicy_success() throws Exception {
+        String body = "{\"adminId\":\"admin-1\",\"policyValue\":\"strict\"}";
+
+        mockMvc.perform(put("/api/admin/policies/CANCELLATION_RULES")
+                .contentType("application/json")
+                .content(body))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.policyKey").value("CANCELLATION_RULES"));
+    }
+
+    @Test
+    void uc12_updatePolicy_success() throws Exception {
+        String createBody = "{\"adminId\":\"admin-1\",\"policyValue\":\"strict\"}";
+        String updateBody = "{\"adminId\":\"admin-1\",\"policyValue\":\"moderate\"}";
+
+        mockMvc.perform(put("/api/admin/policies/REFUND_POLICY")
+                .contentType("application/json")
+                .content(createBody))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(put("/api/admin/policies/REFUND_POLICY")
+                .contentType("application/json")
+                .content(updateBody))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.policyValue").value("moderate"));
+    }
+
+    @Test
+    void uc12_invalidPolicyKey_validationError() throws Exception {
+        String body = "{\"adminId\":\"admin-1\",\"policyValue\":\"x\"}";
+
+        mockMvc.perform(put("/api/admin/policies/UNKNOWN_KEY")
+                .contentType("application/json")
+                .content(body))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("unsupported policyKey"));
+    }
+
+    @Test
+    void uc12_missingAdminId_validationError() throws Exception {
+        String body = "{\"adminId\":\"\",\"policyValue\":\"x\"}";
+
+        mockMvc.perform(put("/api/admin/policies/PRICING_STRATEGY")
+                .contentType("application/json")
+                .content(body))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.details.adminId").value("adminId is required"));
+    }
+
+    private void createPendingConsultant(Long consultantId) {
+        ConsultantRegistration registration = new ConsultantRegistration();
+        registration.setConsultantId(consultantId);
+        registration.setStatus(ConsultantApprovalStatus.PENDING);
+        registration.setCreatedAt(Instant.now());
+        consultantRegistrationRepository.save(registration);
+    }
+}

--- a/backend/src/test/java/com/consultingplatform/admin/repository/ConsultantRegistrationRepositoryTest.java
+++ b/backend/src/test/java/com/consultingplatform/admin/repository/ConsultantRegistrationRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.consultingplatform.admin.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
+import com.consultingplatform.admin.domain.ConsultantRegistration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ConsultantRegistrationRepositoryTest {
+
+    @Autowired
+    private ConsultantRegistrationRepository repository;
+
+    @Test
+    void findByConsultantId_returnsPersistedEntity() {
+        ConsultantRegistration registration = new ConsultantRegistration();
+        registration.setConsultantId(2001L);
+        registration.setStatus(ConsultantApprovalStatus.PENDING);
+        registration.setCreatedAt(Instant.now());
+
+        repository.saveAndFlush(registration);
+
+        assertTrue(repository.findByConsultantId(2001L).isPresent());
+    }
+
+    @Test
+    void uniqueConsultantId_enforced() {
+        ConsultantRegistration first = new ConsultantRegistration();
+        first.setConsultantId(2002L);
+        first.setStatus(ConsultantApprovalStatus.PENDING);
+        first.setCreatedAt(Instant.now());
+        repository.saveAndFlush(first);
+
+        ConsultantRegistration duplicate = new ConsultantRegistration();
+        duplicate.setConsultantId(2002L);
+        duplicate.setStatus(ConsultantApprovalStatus.PENDING);
+        duplicate.setCreatedAt(Instant.now());
+
+        assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(duplicate));
+    }
+
+    @Test
+    void enumAndTimestamp_roundTripPersistence() {
+        ConsultantRegistration registration = new ConsultantRegistration();
+        registration.setConsultantId(2003L);
+        registration.setStatus(ConsultantApprovalStatus.REJECTED);
+        registration.setCreatedAt(Instant.now());
+        registration.setDecidedAt(Instant.now());
+        registration.setApprovedByAdminId("admin-1");
+
+        ConsultantRegistration saved = repository.saveAndFlush(registration);
+
+        ConsultantRegistration loaded = repository.findById(saved.getId()).orElseThrow();
+        assertEquals(ConsultantApprovalStatus.REJECTED, loaded.getStatus());
+        assertEquals("admin-1", loaded.getApprovedByAdminId());
+    }
+}

--- a/backend/src/test/java/com/consultingplatform/admin/repository/SystemPolicyRepositoryTest.java
+++ b/backend/src/test/java/com/consultingplatform/admin/repository/SystemPolicyRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.consultingplatform.admin.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.consultingplatform.admin.domain.SystemPolicy;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class SystemPolicyRepositoryTest {
+
+    @Autowired
+    private SystemPolicyRepository repository;
+
+    @Test
+    void findByPolicyKey_returnsPersistedPolicy() {
+        SystemPolicy policy = new SystemPolicy();
+        policy.setPolicyKey("CANCELLATION_RULES");
+        policy.setPolicyValue("strict");
+        policy.setUpdatedByAdminId("admin-1");
+        policy.setUpdatedAt(Instant.now());
+
+        repository.saveAndFlush(policy);
+
+        assertTrue(repository.findByPolicyKey("CANCELLATION_RULES").isPresent());
+    }
+
+    @Test
+    void uniquePolicyKey_enforced() {
+        SystemPolicy first = new SystemPolicy();
+        first.setPolicyKey("REFUND_POLICY");
+        first.setPolicyValue("standard");
+        first.setUpdatedByAdminId("admin-1");
+        first.setUpdatedAt(Instant.now());
+        repository.saveAndFlush(first);
+
+        SystemPolicy duplicate = new SystemPolicy();
+        duplicate.setPolicyKey("REFUND_POLICY");
+        duplicate.setPolicyValue("strict");
+        duplicate.setUpdatedByAdminId("admin-2");
+        duplicate.setUpdatedAt(Instant.now());
+
+        assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(duplicate));
+    }
+
+    @Test
+    void persistedValues_roundTrip() {
+        SystemPolicy policy = new SystemPolicy();
+        policy.setPolicyKey("NOTIFICATION_SETTINGS");
+        policy.setPolicyValue("email-only");
+        policy.setUpdatedByAdminId("admin-2");
+        policy.setUpdatedAt(Instant.now());
+
+        SystemPolicy saved = repository.saveAndFlush(policy);
+        SystemPolicy loaded = repository.findById(saved.getId()).orElseThrow();
+
+        assertEquals("NOTIFICATION_SETTINGS", loaded.getPolicyKey());
+        assertEquals("email-only", loaded.getPolicyValue());
+        assertEquals("admin-2", loaded.getUpdatedByAdminId());
+    }
+}

--- a/backend/src/test/java/com/consultingplatform/admin/service/ConsultantApprovalServiceImplTest.java
+++ b/backend/src/test/java/com/consultingplatform/admin/service/ConsultantApprovalServiceImplTest.java
@@ -1,0 +1,94 @@
+package com.consultingplatform.admin.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
+import com.consultingplatform.admin.domain.ConsultantRegistration;
+import com.consultingplatform.admin.repository.ConsultantRegistrationRepository;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalDecision;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalRequestDto;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalResponseDto;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConsultantApprovalServiceImplTest {
+
+    @Mock
+    private ConsultantRegistrationRepository repository;
+
+    @InjectMocks
+    private ConsultantApprovalServiceImpl service;
+
+    @Test
+    void approvePendingConsultant_success() {
+        ConsultantRegistration registration = new ConsultantRegistration();
+        registration.setConsultantId(1001L);
+        registration.setStatus(ConsultantApprovalStatus.PENDING);
+        registration.setCreatedAt(Instant.now());
+
+        ConsultantApprovalRequestDto request = new ConsultantApprovalRequestDto();
+        request.setAdminId("admin-1");
+        request.setDecision(ConsultantApprovalDecision.APPROVE);
+
+        when(repository.findByConsultantId(1001L)).thenReturn(Optional.of(registration));
+        when(repository.save(any(ConsultantRegistration.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ConsultantApprovalResponseDto response = service.approveOrRejectConsultant(1001L, request);
+
+        assertEquals(ConsultantApprovalStatus.APPROVED, response.getNewStatus());
+        assertEquals("admin-1", response.getApprovedByAdminId());
+        assertNotNull(response.getDecidedAt());
+        verify(repository).save(any(ConsultantRegistration.class));
+    }
+
+    @Test
+    void rejectPendingConsultant_success() {
+        ConsultantRegistration registration = new ConsultantRegistration();
+        registration.setConsultantId(1001L);
+        registration.setStatus(ConsultantApprovalStatus.PENDING);
+        registration.setCreatedAt(Instant.now());
+
+        ConsultantApprovalRequestDto request = new ConsultantApprovalRequestDto();
+        request.setAdminId("admin-1");
+        request.setDecision(ConsultantApprovalDecision.REJECT);
+
+        when(repository.findByConsultantId(1001L)).thenReturn(Optional.of(registration));
+        when(repository.save(any(ConsultantRegistration.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ConsultantApprovalResponseDto response = service.approveOrRejectConsultant(1001L, request);
+
+        assertEquals(ConsultantApprovalStatus.REJECTED, response.getNewStatus());
+        assertEquals("admin-1", response.getApprovedByAdminId());
+        assertNotNull(response.getDecidedAt());
+    }
+
+    @Test
+    void consultantNotFound_failsWithNotFound() {
+        ConsultantApprovalRequestDto request = new ConsultantApprovalRequestDto();
+        request.setAdminId("admin-1");
+        request.setDecision(ConsultantApprovalDecision.APPROVE);
+
+        when(repository.findByConsultantId(404L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> service.approveOrRejectConsultant(404L, request));
+    }
+
+    @Test
+    void missingDecision_failsValidation() {
+        ConsultantApprovalRequestDto request = new ConsultantApprovalRequestDto();
+        request.setAdminId("admin-1");
+
+        assertThrows(IllegalArgumentException.class, () -> service.approveOrRejectConsultant(1001L, request));
+    }
+}

--- a/backend/src/test/java/com/consultingplatform/admin/service/SystemPolicyServiceImplTest.java
+++ b/backend/src/test/java/com/consultingplatform/admin/service/SystemPolicyServiceImplTest.java
@@ -1,0 +1,92 @@
+package com.consultingplatform.admin.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.consultingplatform.admin.domain.SystemPolicy;
+import com.consultingplatform.admin.repository.SystemPolicyRepository;
+import com.consultingplatform.admin.web.dto.PolicyUpsertRequestDto;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SystemPolicyServiceImplTest {
+
+    @Mock
+    private SystemPolicyRepository repository;
+
+    @InjectMocks
+    private SystemPolicyServiceImpl service;
+
+    @Test
+    void createNewPolicy_success() {
+        PolicyUpsertRequestDto request = new PolicyUpsertRequestDto();
+        request.setAdminId("admin-1");
+        request.setPolicyValue("strict");
+
+        when(repository.findByPolicyKey("CANCELLATION_RULES")).thenReturn(Optional.empty());
+        when(repository.save(any(SystemPolicy.class))).thenAnswer(invocation -> {
+            SystemPolicy policy = invocation.getArgument(0);
+            policy.setId(1L);
+            return policy;
+        });
+
+        PolicyUpsertResult result = service.upsertPolicy("CANCELLATION_RULES", request);
+
+        assertEquals(true, result.isCreated());
+        assertEquals("CANCELLATION_RULES", result.getResponse().getPolicyKey());
+        assertEquals("strict", result.getResponse().getPolicyValue());
+    }
+
+    @Test
+    void updateExistingPolicy_success() {
+        PolicyUpsertRequestDto request = new PolicyUpsertRequestDto();
+        request.setAdminId("admin-2");
+        request.setPolicyValue("dynamic");
+
+        SystemPolicy existing = new SystemPolicy();
+        existing.setId(11L);
+        existing.setPolicyKey("PRICING_STRATEGY");
+        existing.setPolicyValue("fixed");
+
+        when(repository.findByPolicyKey("PRICING_STRATEGY")).thenReturn(Optional.of(existing));
+        when(repository.save(any(SystemPolicy.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PolicyUpsertResult result = service.upsertPolicy("pricing_strategy", request);
+
+        assertEquals(false, result.isCreated());
+        assertEquals("PRICING_STRATEGY", result.getResponse().getPolicyKey());
+        assertEquals("dynamic", result.getResponse().getPolicyValue());
+    }
+
+    @Test
+    void missingAdminId_validationError() {
+        PolicyUpsertRequestDto request = new PolicyUpsertRequestDto();
+        request.setPolicyValue("enabled");
+
+        assertThrows(IllegalArgumentException.class, () -> service.upsertPolicy("NOTIFICATION_SETTINGS", request));
+    }
+
+    @Test
+    void missingPolicyValue_validationError() {
+        PolicyUpsertRequestDto request = new PolicyUpsertRequestDto();
+        request.setAdminId("admin-1");
+
+        assertThrows(IllegalArgumentException.class, () -> service.upsertPolicy("NOTIFICATION_SETTINGS", request));
+    }
+
+    @Test
+    void unsupportedPolicyKey_validationError() {
+        PolicyUpsertRequestDto request = new PolicyUpsertRequestDto();
+        request.setAdminId("admin-1");
+        request.setPolicyValue("x");
+
+        assertThrows(IllegalArgumentException.class, () -> service.upsertPolicy("UNKNOWN_POLICY", request));
+    }
+}

--- a/backend/src/test/java/com/consultingplatform/admin/web/AdminControllerTest.java
+++ b/backend/src/test/java/com/consultingplatform/admin/web/AdminControllerTest.java
@@ -1,0 +1,122 @@
+package com.consultingplatform.admin.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.consultingplatform.admin.repository.ConsultantRegistrationRepository;
+import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
+import com.consultingplatform.admin.service.ConflictException;
+import com.consultingplatform.admin.service.ConsultantApprovalService;
+import com.consultingplatform.admin.service.PolicyUpsertResult;
+import com.consultingplatform.admin.service.SystemPolicyService;
+import com.consultingplatform.admin.web.dto.ConsultantApprovalResponseDto;
+import com.consultingplatform.admin.web.dto.PolicyResponseDto;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AdminControllerTest {
+
+    private MockMvc mockMvc;
+    private ConsultantApprovalService consultantApprovalService;
+    private SystemPolicyService systemPolicyService;
+    private ConsultantRegistrationRepository consultantRegistrationRepository;
+
+    @BeforeEach
+    void setup() {
+        consultantApprovalService = Mockito.mock(ConsultantApprovalService.class);
+        systemPolicyService = Mockito.mock(SystemPolicyService.class);
+        consultantRegistrationRepository = Mockito.mock(ConsultantRegistrationRepository.class);
+
+        AdminController controller = new AdminController(
+            consultantApprovalService,
+            systemPolicyService,
+            consultantRegistrationRepository
+        );
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+    }
+
+    @Test
+    void approveConsultant_success() throws Exception {
+        ConsultantApprovalResponseDto response = new ConsultantApprovalResponseDto(
+            1001L,
+            ConsultantApprovalStatus.APPROVED,
+            "admin-1",
+            Instant.now()
+        );
+        when(consultantApprovalService.approveOrRejectConsultant(eq(1001L), any())).thenReturn(response);
+
+        String body = "{\"adminId\":\"admin-1\",\"decision\":\"APPROVE\",\"reason\":\"ok\"}";
+
+        mockMvc.perform(post("/api/admin/consultants/1001/approval")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.consultantId").value(1001))
+            .andExpect(jsonPath("$.newStatus").value("APPROVED"));
+    }
+
+    @Test
+    void reapproveConsultant_conflict() throws Exception {
+        when(consultantApprovalService.approveOrRejectConsultant(eq(1001L), any()))
+            .thenThrow(new ConflictException("Consultant registration already decided"));
+
+        String body = "{\"adminId\":\"admin-1\",\"decision\":\"APPROVE\",\"reason\":\"\"}";
+
+        mockMvc.perform(post("/api/admin/consultants/1001/approval")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CONFLICT"));
+    }
+
+    @Test
+    void createPolicy_success201() throws Exception {
+        PolicyResponseDto response = new PolicyResponseDto("CANCELLATION_RULES", "strict", "admin-2", Instant.now());
+        when(systemPolicyService.upsertPolicy(eq("CANCELLATION_RULES"), any()))
+            .thenReturn(new PolicyUpsertResult(true, response));
+
+        String body = "{\"adminId\":\"admin-2\",\"policyValue\":\"strict\"}";
+
+        mockMvc.perform(put("/api/admin/policies/CANCELLATION_RULES")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.policyKey").value("CANCELLATION_RULES"));
+    }
+
+    @Test
+    void missingAdminId_validationError400() throws Exception {
+        String body = "{\"adminId\":\"\",\"policyValue\":\"standard\"}";
+
+        mockMvc.perform(put("/api/admin/policies/REFUND_POLICY")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.details.adminId").value("adminId is required"));
+    }
+
+    @Test
+    void missingDecision_validationError400() throws Exception {
+        String body = "{\"adminId\":\"admin-1\"}";
+
+        mockMvc.perform(post("/api/admin/consultants/1001/approval")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.details.decision").value("decision is required"));
+    }
+
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:admin_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Introduce admin functionality: add ConsultantRegistration and SystemPolicy JPA entities and ConsultantApprovalStatus enum, plus repositories. Implement ConsultantApprovalService and SystemPolicyService (with implementations, custom exceptions and PolicyUpsertResult) and REST AdminController with DTOs for approval and policy upsert. Add global error handling (ApiErrorResponse, GlobalExceptionHandler) and validation annotations. Include comprehensive unit and integration tests, H2 test configuration and activate test profile; add spring-boot-starter-validation and H2 test dependency to pom.xml. Update .gitignore and backend/.dockerignore to ignore logs, DB files, build outputs and environment files.