### PR TITLE
Add MODEL policy type to system policies

### DIFF
--- a/backend/src/main/java/com/consultingplatform/admin/service/SystemPolicyServiceImpl.java
+++ b/backend/src/main/java/com/consultingplatform/admin/service/SystemPolicyServiceImpl.java
@@ -15,7 +15,8 @@ public class SystemPolicyServiceImpl implements SystemPolicyService {
         "CANCELLATION_RULES",
         "PRICING_STRATEGY",
         "NOTIFICATION_SETTINGS",
-        "REFUND_POLICY"
+        "REFUND_POLICY",
+        "MODEL"
     );
 
     private final SystemPolicyRepository repository;


### PR DESCRIPTION
Include the "MODEL" identifier in the static list of system policy keys in SystemPolicyServiceImpl so model-related policies are recognized by the service. This change updates the policy types handled by the service.