### PR TITLE
Add localdb profile and LOCAL_* env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,18 @@
 services:
   db:
+    profiles: ["localdb"]
     image: postgres:16-alpine
     container_name: eecs3311-db
     environment:
-      POSTGRES_DB: ${DB_NAME:-consulting_db}
-      POSTGRES_USER: ${DB_USER:-admin}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
+      POSTGRES_DB: ${LOCAL_DB_NAME:-consulting_db}
+      POSTGRES_USER: ${LOCAL_DB_USER:-admin}
+      POSTGRES_PASSWORD: ${LOCAL_DB_PASSWORD:-changeme}
     ports:
-      - "${DB_PORT:-5432}:5432"
+      - "${LOCAL_DB_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-admin} -d ${DB_NAME:-consulting_db}"]
+      test: ["CMD-SHELL", "pg_isready -U ${LOCAL_DB_USER:-admin} -d ${LOCAL_DB_NAME:-consulting_db}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -23,7 +24,7 @@ services:
     container_name: eecs3311-backend
     environment:
       SERVER_PORT: ${SPRING_PORT:-8080}
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://${DB_HOST:-db}:5432/${DB_NAME:-consulting_db}}
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://${LOCAL_DB_HOST:-db}:5432/${LOCAL_DB_NAME:-consulting_db}}
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-admin}
       SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:-changeme}
       DB_SSLMODE: ${DB_SSLMODE:-disable}
@@ -31,9 +32,6 @@ services:
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
     ports:
       - "${SPRING_PORT:-8080}:${SPRING_PORT:-8080}"
-    depends_on:
-      db:
-        condition: service_healthy
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Add a "localdb" compose profile and switch DB-related environment variables to LOCAL_* (name, user, password, port, host) so local overrides are isolated from other envs. Update the db healthcheck and the backend SPRING_DATASOURCE_URL to reference the new LOCAL_* variables. Remove the backend's depends_on service_healthy block. These changes allow running a local Postgres instance via a dedicated profile and configurable local env vars.