### PR TITLE
Associate availability slots with consulting services

### DIFF
--- a/backend/docs/consulting_db_schema.sql
+++ b/backend/docs/consulting_db_schema.sql
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS consulting_services (
 CREATE TABLE IF NOT EXISTS consultant_availability_slots (
     id BIGSERIAL PRIMARY KEY,
     consultant_id BIGINT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+    service_id BIGINT NOT NULL REFERENCES consulting_services(id) ON DELETE CASCADE,
     start_at TIMESTAMPTZ NOT NULL,
     end_at TIMESTAMPTZ NOT NULL,
     is_available BOOLEAN NOT NULL DEFAULT TRUE,
@@ -259,7 +260,7 @@ CREATE INDEX IF NOT EXISTS idx_consulting_services_consultant_active
     ON consulting_services (consultant_id, is_active);
 
 CREATE INDEX IF NOT EXISTS idx_availability_consultant_start
-    ON consultant_availability_slots (consultant_id, start_at);
+    ON consultant_availability_slots (consultant_id, service_id, start_at);
 
 CREATE INDEX IF NOT EXISTS idx_bookings_client_requested_at
     ON bookings (client_id, requested_at DESC);

--- a/backend/src/main/java/com/consultingplatform/consultant/domain/AvailabilitySlot.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/domain/AvailabilitySlot.java
@@ -18,6 +18,9 @@ public class AvailabilitySlot {
     @Column(name = "consultant_id", nullable = false)
     private Long consultantId;
 
+    @Column(name = "service_id", nullable = false)
+    private Long serviceId;
+
     @Column(name = "start_at", nullable = false)
     private OffsetDateTime startAt;
 

--- a/backend/src/main/java/com/consultingplatform/consultant/service/ConsultantServiceImpl.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/service/ConsultantServiceImpl.java
@@ -5,9 +5,12 @@ import com.consultingplatform.booking.domain.Booking;
 import com.consultingplatform.booking.repository.BookingRepository;
 import com.consultingplatform.consultant.domain.AvailabilitySlot;
 import com.consultingplatform.consultant.repository.AvailabilitySlotRepository;
+import com.consultingplatform.service.domain.ConsultingService;
+import com.consultingplatform.service.repository.ConsultingServiceRepository;
 import com.consultingplatform.consultant.web.dto.*;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -16,17 +19,44 @@ public class ConsultantServiceImpl implements ConsultantService {
 
     private final AvailabilitySlotRepository availabilitySlotRepository;
     private final BookingRepository bookingRepository;
+    private final ConsultingServiceRepository consultingServiceRepository;
 
     public ConsultantServiceImpl(AvailabilitySlotRepository availabilitySlotRepository,
-                                 BookingRepository bookingRepository) {
+                                 BookingRepository bookingRepository,
+                                 ConsultingServiceRepository consultingServiceRepository) {
         this.availabilitySlotRepository = availabilitySlotRepository;
         this.bookingRepository = bookingRepository;
+        this.consultingServiceRepository = consultingServiceRepository;
     }
 
     @Override
     public AvailabilitySlotResponse createAvailabilitySlot(Long consultantId, CreateAvailabilitySlotRequest request) {
+        ConsultingService consultingService = consultingServiceRepository.findById(request.getServiceId())
+                .orElseThrow(() -> new ResourceNotFoundException("Consulting service not found"));
+
+        boolean serviceIsActive = Boolean.TRUE.equals(consultingService.getIsActive());
+        if (!serviceIsActive) {
+            throw new IllegalStateException("Consulting service is inactive");
+        }
+
+        boolean serviceBelongsToConsultant = consultingService.getConsultantId().equals(consultantId);
+        if (!serviceBelongsToConsultant) {
+            throw new IllegalStateException("Consultant can only add slots for their own services");
+        }
+
+        if (consultingService.getDurationMinutes() == null || consultingService.getDurationMinutes() <= 0) {
+            throw new IllegalStateException("Consulting service has invalid duration");
+        }
+
         if (!request.getEndAt().isAfter(request.getStartAt())) {
             throw new IllegalStateException("end_at must be after start_at");
+        }
+
+        Duration requestedDuration = Duration.between(request.getStartAt(), request.getEndAt());
+        Duration serviceDuration = Duration.ofMinutes(consultingService.getDurationMinutes());
+        boolean slotMatchesServiceDuration = requestedDuration.equals(serviceDuration);
+        if (!slotMatchesServiceDuration) {
+            throw new IllegalStateException("Availability slot duration must match service duration");
         }
 
         boolean overlapping = availabilitySlotRepository.existsOverlappingSlot(
@@ -37,6 +67,7 @@ public class ConsultantServiceImpl implements ConsultantService {
 
         AvailabilitySlot slot = new AvailabilitySlot();
         slot.setConsultantId(consultantId);
+        slot.setServiceId(request.getServiceId());
         slot.setStartAt(request.getStartAt());
         slot.setEndAt(request.getEndAt());
         slot.setIsAvailable(true);
@@ -114,7 +145,7 @@ public class ConsultantServiceImpl implements ConsultantService {
 
     private AvailabilitySlotResponse toSlotResponse(AvailabilitySlot slot) {
         return new AvailabilitySlotResponse(
-                slot.getId(), slot.getConsultantId(), slot.getStartAt(),
+                slot.getId(), slot.getConsultantId(), slot.getServiceId(), slot.getStartAt(),
                 slot.getEndAt(), slot.getIsAvailable(), slot.getCreatedAt());
     }
 

--- a/backend/src/main/java/com/consultingplatform/consultant/web/dto/AvailabilitySlotResponse.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/web/dto/AvailabilitySlotResponse.java
@@ -6,15 +6,17 @@ public class AvailabilitySlotResponse {
 
     private Long id;
     private Long consultantId;
+    private Long serviceId;
     private OffsetDateTime startAt;
     private OffsetDateTime endAt;
     private Boolean isAvailable;
     private OffsetDateTime createdAt;
 
-    public AvailabilitySlotResponse(Long id, Long consultantId, OffsetDateTime startAt,
+    public AvailabilitySlotResponse(Long id, Long consultantId, Long serviceId, OffsetDateTime startAt,
                                     OffsetDateTime endAt, Boolean isAvailable, OffsetDateTime createdAt) {
         this.id = id;
         this.consultantId = consultantId;
+        this.serviceId = serviceId;
         this.startAt = startAt;
         this.endAt = endAt;
         this.isAvailable = isAvailable;
@@ -23,6 +25,7 @@ public class AvailabilitySlotResponse {
 
     public Long getId() { return id; }
     public Long getConsultantId() { return consultantId; }
+    public Long getServiceId() { return serviceId; }
     public OffsetDateTime getStartAt() { return startAt; }
     public OffsetDateTime getEndAt() { return endAt; }
     public Boolean getIsAvailable() { return isAvailable; }

--- a/backend/src/main/java/com/consultingplatform/consultant/web/dto/CreateAvailabilitySlotRequest.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/web/dto/CreateAvailabilitySlotRequest.java
@@ -6,12 +6,17 @@ import java.time.OffsetDateTime;
 
 public class CreateAvailabilitySlotRequest {
 
+    @NotNull(message = "serviceId is required")
+    private Long serviceId;
+
     @NotNull(message = "startAt is required")
     private OffsetDateTime startAt;
 
     @NotNull(message = "endAt is required")
     private OffsetDateTime endAt;
 
+    public Long getServiceId() { return serviceId; }
+    public void setServiceId(Long serviceId) { this.serviceId = serviceId; }
     public OffsetDateTime getStartAt() { return startAt; }
     public void setStartAt(OffsetDateTime startAt) { this.startAt = startAt; }
     public OffsetDateTime getEndAt() { return endAt; }

--- a/backend/src/main/java/com/consultingplatform/service/repository/ConsultingServiceRepository.java
+++ b/backend/src/main/java/com/consultingplatform/service/repository/ConsultingServiceRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ConsultingServiceRepository extends JpaRepository<ConsultingService, Long> {
@@ -14,4 +15,8 @@ public interface ConsultingServiceRepository extends JpaRepository<ConsultingSer
     List<ConsultingService> findByConsultantIdAndIsActiveTrue(Long consultantId);
     
     List<ConsultingService> findByServiceTypeAndIsActiveTrue(String serviceType);
+
+    boolean existsByIdAndConsultantIdAndIsActiveTrue(Long id, Long consultantId);
+
+    Optional<ConsultingService> findByIdAndConsultantIdAndIsActiveTrue(Long id, Long consultantId);
 }


### PR DESCRIPTION
Add service_id to consultant_availability_slots (and index) and wire it through the domain, DTOs, and persistence. CreateAvailabilitySlotRequest now requires serviceId and AvailabilitySlotResponse exposes it. ConsultantServiceImpl now looks up the ConsultingService and enforces that the service exists, is active, belongs to the consultant, and that the slot duration equals the service duration before creating a slot. ConsultingServiceRepository gained helper methods to query/validate services by id/consultant/active status.