### PR TITLE
Refactor ConsultingService into consultant package

### DIFF
--- a/backend/src/main/java/com/consultingplatform/consultant/domain/ConsultingService.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/domain/ConsultingService.java
@@ -1,4 +1,4 @@
-package com.consultingplatform.service.domain;
+package com.consultingplatform.consultant.domain;
 
 import jakarta.persistence.*;
 import lombok.Data;

--- a/backend/src/main/java/com/consultingplatform/consultant/repository/ConsultingServiceRepository.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/repository/ConsultingServiceRepository.java
@@ -1,6 +1,6 @@
-package com.consultingplatform.service.repository;
+package com.consultingplatform.consultant.repository;
 
-import com.consultingplatform.service.domain.ConsultingService;
+import com.consultingplatform.consultant.domain.ConsultingService;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/backend/src/main/java/com/consultingplatform/consultant/service/ConsultantServiceImpl.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/service/ConsultantServiceImpl.java
@@ -5,8 +5,8 @@ import com.consultingplatform.booking.domain.Booking;
 import com.consultingplatform.booking.repository.BookingRepository;
 import com.consultingplatform.consultant.domain.AvailabilitySlot;
 import com.consultingplatform.consultant.repository.AvailabilitySlotRepository;
-import com.consultingplatform.service.domain.ConsultingService;
-import com.consultingplatform.service.repository.ConsultingServiceRepository;
+import com.consultingplatform.consultant.domain.ConsultingService;
+import com.consultingplatform.consultant.repository.ConsultingServiceRepository;
 import com.consultingplatform.consultant.web.dto.*;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/com/consultingplatform/consultant/web/ConsultingServiceController.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/web/ConsultingServiceController.java
@@ -1,7 +1,7 @@
-package com.consultingplatform.service.web;
+package com.consultingplatform.consultant.web;
 
-import com.consultingplatform.service.domain.ConsultingService;
-import com.consultingplatform.service.repository.ConsultingServiceRepository;
+import com.consultingplatform.consultant.domain.ConsultingService;
+import com.consultingplatform.consultant.repository.ConsultingServiceRepository;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;


### PR DESCRIPTION
Move ConsultingService domain, repository and controller from com.consultingplatform.service.* to com.consultingplatform.consultant.* and update imports/references accordingly. Files renamed and package declarations adjusted; ConsultantServiceImpl imports updated to reference the new consultant package. No functional logic changed—this is a package reorganization to group consultant-related classes.