### PR TITLE
Add notification system and integrate with bookings

### DIFF
--- a/backend/src/main/java/com/consultingplatform/booking/service/BookingServiceImpl.java
+++ b/backend/src/main/java/com/consultingplatform/booking/service/BookingServiceImpl.java
@@ -5,6 +5,7 @@ import com.consultingplatform.booking.repository.BookingRepository;
 import com.consultingplatform.booking.web.BookingRequest;
 import com.consultingplatform.consultant.domain.AvailabilitySlot;
 import com.consultingplatform.consultant.repository.AvailabilitySlotRepository;
+import com.consultingplatform.notification.service.NotificationService;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,11 +16,14 @@ public class BookingServiceImpl implements BookingService {
 
     private final BookingRepository bookingRepository;
     private final AvailabilitySlotRepository availabilitySlotRepository;
+    private final NotificationService notificationService;
 
     public BookingServiceImpl(BookingRepository bookingRepository,
-                            AvailabilitySlotRepository availabilitySlotRepository) {
+                            AvailabilitySlotRepository availabilitySlotRepository,
+                            NotificationService notificationService) {
         this.bookingRepository = bookingRepository;
         this.availabilitySlotRepository = availabilitySlotRepository;
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -75,7 +79,9 @@ public class BookingServiceImpl implements BookingService {
                     });
         }
 
-        return bookingRepository.save(booking);
+        Booking cancelled = bookingRepository.save(booking);
+        notificationService.sendBookingCancelledNotifications(cancelled);
+        return cancelled;
     }
 
     @Override

--- a/backend/src/main/java/com/consultingplatform/consultant/service/ConsultantServiceImpl.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/service/ConsultantServiceImpl.java
@@ -8,6 +8,7 @@ import com.consultingplatform.consultant.repository.AvailabilitySlotRepository;
 import com.consultingplatform.consultant.domain.ConsultingService;
 import com.consultingplatform.consultant.repository.ConsultingServiceRepository;
 import com.consultingplatform.consultant.web.dto.*;
+import com.consultingplatform.notification.service.NotificationService;
 
 import jakarta.transaction.Transactional;
 
@@ -27,15 +28,18 @@ public class ConsultantServiceImpl implements ConsultantService {
     private final BookingRepository bookingRepository;
     private final ConsultingServiceRepository consultingServiceRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     public ConsultantServiceImpl(AvailabilitySlotRepository availabilitySlotRepository,
                                  BookingRepository bookingRepository,
                                  ConsultingServiceRepository consultingServiceRepository,
-                                 UserRepository userRepository) {
+                                 UserRepository userRepository,
+                                 NotificationService notificationService) {
         this.availabilitySlotRepository = availabilitySlotRepository;
         this.bookingRepository = bookingRepository;
         this.consultingServiceRepository = consultingServiceRepository;
         this.userRepository = userRepository;
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -162,6 +166,7 @@ public class ConsultantServiceImpl implements ConsultantService {
         }
         
         Booking saved = bookingRepository.save(booking);
+        notificationService.sendBookingRejectedNotificationToClient(saved, saved.getRejectionReason());
         return toBookingResponse(saved);
     }
 

--- a/backend/src/main/java/com/consultingplatform/notification/domain/Notification.java
+++ b/backend/src/main/java/com/consultingplatform/notification/domain/Notification.java
@@ -1,0 +1,53 @@
+package com.consultingplatform.notification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "notifications")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type", nullable = false)
+    private NotificationType notificationType;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @jakarta.persistence.PrePersist
+    public void onCreate() {
+        if (isRead == null) {
+            isRead = false;
+        }
+    }
+}

--- a/backend/src/main/java/com/consultingplatform/notification/domain/NotificationType.java
+++ b/backend/src/main/java/com/consultingplatform/notification/domain/NotificationType.java
@@ -1,0 +1,12 @@
+package com.consultingplatform.notification.domain;
+
+public enum NotificationType {
+    BOOKING_REQUESTED,
+    BOOKING_CONFIRMED,
+    BOOKING_REJECTED,
+    BOOKING_CANCELLED,
+    PAYMENT_SUCCESS,
+    PAYMENT_FAILED,
+    PAYMENT_REFUNDED,
+    POLICY_UPDATED
+}

--- a/backend/src/main/java/com/consultingplatform/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/consultingplatform/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.consultingplatform.notification.repository;
+
+import com.consultingplatform.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/backend/src/main/java/com/consultingplatform/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/consultingplatform/notification/service/NotificationService.java
@@ -1,0 +1,57 @@
+package com.consultingplatform.notification.service;
+
+import com.consultingplatform.booking.domain.Booking;
+import com.consultingplatform.notification.domain.Notification;
+import com.consultingplatform.notification.domain.NotificationType;
+import com.consultingplatform.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public void sendBookingCancelledNotifications(Booking booking) {
+        String payload = buildBookingCancelledPayload(booking);
+
+        Notification clientNotification = Notification.builder()
+                .userId(booking.getClientId())
+                .notificationType(NotificationType.BOOKING_CANCELLED)
+                .payload(payload)
+                .build();
+
+        Notification consultantNotification = Notification.builder()
+                .userId(booking.getConsultantId())
+                .notificationType(NotificationType.BOOKING_CANCELLED)
+                .payload(payload)
+                .build();
+
+        notificationRepository.save(clientNotification);
+        notificationRepository.save(consultantNotification);
+    }
+
+    public void sendBookingRejectedNotificationToClient(Booking booking, String reason) {
+        String payload = buildBookingRejectedPayload(booking, reason);
+
+        Notification clientNotification = Notification.builder()
+                .userId(booking.getClientId())
+                .notificationType(NotificationType.BOOKING_REJECTED)
+                .payload(payload)
+                .build();
+
+        notificationRepository.save(clientNotification);
+    }
+
+    private String buildBookingCancelledPayload(Booking booking) {
+        return "Booking " + booking.getId() + " was cancelled. Status: " + booking.getStatus();
+    }
+
+    private String buildBookingRejectedPayload(Booking booking, String reason) {
+        if (reason != null && !reason.isBlank()) {
+            return "Booking " + booking.getId() + " was rejected by consultant. Reason: " + reason;
+        }
+        return "Booking " + booking.getId() + " was rejected by consultant.";
+    }
+}


### PR DESCRIPTION
Introduce a notification subsystem: add Notification entity, NotificationType enum, and NotificationRepository, plus a NotificationService that builds and persists notifications for booking cancellations and rejections. Wire NotificationService into BookingServiceImpl and ConsultantServiceImpl via constructor injection and invoke sendBookingCancelledNotifications(...) after saving a cancelled booking and sendBookingRejectedNotificationToClient(...) after saving a rejected booking. Cancellation notifications are created for both client and consultant; rejection notifications are sent to the client. Payload formatting helpers are implemented in the service.