### PR TITLE
Enforce admin validation for consultant approvals

### DIFF
--- a/backend/src/main/java/com/consultingplatform/admin/web/AdminController.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/AdminController.java
@@ -10,6 +10,8 @@ import com.consultingplatform.admin.web.dto.ConsultantApprovalRequestDto;
 import com.consultingplatform.admin.web.dto.ConsultantApprovalResponseDto;
 import com.consultingplatform.admin.web.dto.PolicyResponseDto;
 import com.consultingplatform.admin.web.dto.PolicyUpsertRequestDto;
+import com.consultingplatform.user.domain.Admin;
+import com.consultingplatform.user.repository.UserRepository;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/admin")
@@ -29,15 +32,18 @@ public class AdminController {
     private final ConsultantApprovalService consultantApprovalService;
     private final SystemPolicyService systemPolicyService;
     private final ConsultantRegistrationRepository consultantRegistrationRepository;
+    private final UserRepository userRepository;
 
     public AdminController(
         ConsultantApprovalService consultantApprovalService,
         SystemPolicyService systemPolicyService,
-        ConsultantRegistrationRepository consultantRegistrationRepository
+        ConsultantRegistrationRepository consultantRegistrationRepository,
+        UserRepository userRepository
     ) {
         this.consultantApprovalService = consultantApprovalService;
         this.systemPolicyService = systemPolicyService;
         this.consultantRegistrationRepository = consultantRegistrationRepository;
+        this.userRepository = userRepository;
     }
 
     @PostMapping("/consultants/{consultantId}/approval")
@@ -45,6 +51,21 @@ public class AdminController {
         @PathVariable Long consultantId,
         @Valid @RequestBody ConsultantApprovalRequestDto request
     ) {
+        String adminId = request.getAdminId();
+        Long adminUserId;
+        try {
+            adminUserId = Long.parseLong(adminId.trim());
+        } catch (Exception ex) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only admin can approve or reject consultant registration");
+        }
+
+        boolean isAdmin = userRepository.findById(adminUserId)
+            .map(user -> user instanceof Admin)
+            .orElse(false);
+        if (!isAdmin) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only admin can approve or reject consultant registration");
+        }
+
         return ResponseEntity.ok(consultantApprovalService.approveOrRejectConsultant(consultantId, request));
     }
 

--- a/backend/src/main/java/com/consultingplatform/admin/web/dto/ConsultantApprovalRequestDto.java
+++ b/backend/src/main/java/com/consultingplatform/admin/web/dto/ConsultantApprovalRequestDto.java
@@ -35,4 +35,5 @@ public class ConsultantApprovalRequestDto {
     public void setReason(String reason) {
         this.reason = reason;
     }
+
 }

--- a/backend/src/main/java/com/consultingplatform/consultant/service/ConsultantServiceImpl.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/service/ConsultantServiceImpl.java
@@ -9,11 +9,12 @@ import com.consultingplatform.consultant.domain.ConsultingService;
 import com.consultingplatform.consultant.repository.ConsultingServiceRepository;
 import com.consultingplatform.consultant.web.dto.*;
 import com.consultingplatform.notification.service.NotificationService;
+import com.consultingplatform.user.domain.Admin;
+import com.consultingplatform.user.domain.Consultant;
+import com.consultingplatform.user.domain.User;
 
 import jakarta.transaction.Transactional;
 
-import com.consultingplatform.user.domain.Consultant;
-import com.consultingplatform.user.domain.User;
 import com.consultingplatform.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
@@ -45,9 +46,9 @@ public class ConsultantServiceImpl implements ConsultantService {
     @Override
     public ConsultingService createConsultingService(Long consultantId, CreateConsultingServiceRequest request) {
         User user = userRepository.findById(consultantId)
-                .orElseThrow(() -> new ResourceNotFoundException("Consultant not found"));
-        if (!(user instanceof Consultant)) {
-            throw new IllegalStateException("Provided id is not a consultant");
+            .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        if (!(user instanceof Admin) && !(user instanceof Consultant)) {
+            throw new IllegalStateException("Only admin or consultant can add services");
         }
 
         ConsultingService service = new ConsultingService();

--- a/backend/src/main/java/com/consultingplatform/consultant/web/dto/CreateConsultingServiceRequest.java
+++ b/backend/src/main/java/com/consultingplatform/consultant/web/dto/CreateConsultingServiceRequest.java
@@ -64,4 +64,5 @@ public class CreateConsultingServiceRequest {
     public void setBasePrice(BigDecimal basePrice) {
         this.basePrice = basePrice;
     }
+
 }

--- a/backend/src/test/java/com/consultingplatform/admin/integration/AdminUc11Uc12IntegrationTest.java
+++ b/backend/src/test/java/com/consultingplatform/admin/integration/AdminUc11Uc12IntegrationTest.java
@@ -11,6 +11,8 @@ import com.consultingplatform.admin.domain.ConsultantApprovalStatus;
 import com.consultingplatform.admin.domain.ConsultantRegistration;
 import com.consultingplatform.admin.repository.ConsultantRegistrationRepository;
 import com.consultingplatform.admin.repository.SystemPolicyRepository;
+import com.consultingplatform.user.domain.Admin;
+import com.consultingplatform.user.repository.UserRepository;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +36,9 @@ class AdminUc11Uc12IntegrationTest {
     @Autowired
     private SystemPolicyRepository systemPolicyRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @BeforeEach
     void setupData() {
         systemPolicyRepository.deleteAll();
@@ -43,8 +48,9 @@ class AdminUc11Uc12IntegrationTest {
     @Test
     void uc11_approveConsultant_success() throws Exception {
         createPendingConsultant(3001L);
+        Long adminId = createAdminUser();
 
-        String body = "{\"adminId\":\"admin-1\",\"decision\":\"APPROVE\",\"reason\":\"verified\"}";
+        String body = "{\"adminId\":\"" + adminId + "\",\"decision\":\"APPROVE\",\"reason\":\"verified\"}";
 
         mockMvc.perform(post("/api/admin/consultants/3001/approval")
                 .contentType("application/json")
@@ -57,7 +63,8 @@ class AdminUc11Uc12IntegrationTest {
     @Test
     void uc11_rejectConsultant_success() throws Exception {
         createPendingConsultant(3002L);
-        String body = "{\"adminId\":\"admin-1\",\"decision\":\"REJECT\",\"reason\":\"incomplete profile\"}";
+        Long adminId = createAdminUser();
+        String body = "{\"adminId\":\"" + adminId + "\",\"decision\":\"REJECT\",\"reason\":\"incomplete profile\"}";
 
         mockMvc.perform(post("/api/admin/consultants/3002/approval")
                 .contentType("application/json")
@@ -145,5 +152,15 @@ class AdminUc11Uc12IntegrationTest {
         registration.setStatus(ConsultantApprovalStatus.PENDING);
         registration.setCreatedAt(Instant.now());
         consultantRegistrationRepository.save(registration);
+    }
+
+    private Long createAdminUser() {
+        Admin admin = new Admin();
+        admin.setEmail("admin-" + System.nanoTime() + "@test.com");
+        admin.setPasswordHash("x");
+        admin.setFirstName("Admin");
+        admin.setLastName("User");
+        admin.setPhoneNumber("1111111111");
+        return userRepository.save(admin).getId();
     }
 }

--- a/backend/src/test/java/com/consultingplatform/admin/web/AdminControllerTest.java
+++ b/backend/src/test/java/com/consultingplatform/admin/web/AdminControllerTest.java
@@ -16,7 +16,10 @@ import com.consultingplatform.admin.service.PolicyUpsertResult;
 import com.consultingplatform.admin.service.SystemPolicyService;
 import com.consultingplatform.admin.web.dto.ConsultantApprovalResponseDto;
 import com.consultingplatform.admin.web.dto.PolicyResponseDto;
+import com.consultingplatform.user.domain.Admin;
+import com.consultingplatform.user.repository.UserRepository;
 import java.time.Instant;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -30,17 +33,20 @@ class AdminControllerTest {
     private ConsultantApprovalService consultantApprovalService;
     private SystemPolicyService systemPolicyService;
     private ConsultantRegistrationRepository consultantRegistrationRepository;
+    private UserRepository userRepository;
 
     @BeforeEach
     void setup() {
         consultantApprovalService = Mockito.mock(ConsultantApprovalService.class);
         systemPolicyService = Mockito.mock(SystemPolicyService.class);
         consultantRegistrationRepository = Mockito.mock(ConsultantRegistrationRepository.class);
+        userRepository = Mockito.mock(UserRepository.class);
 
         AdminController controller = new AdminController(
             consultantApprovalService,
             systemPolicyService,
-            consultantRegistrationRepository
+            consultantRegistrationRepository,
+            userRepository
         );
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
             .setControllerAdvice(new GlobalExceptionHandler())
@@ -52,12 +58,14 @@ class AdminControllerTest {
         ConsultantApprovalResponseDto response = new ConsultantApprovalResponseDto(
             1001L,
             ConsultantApprovalStatus.APPROVED,
-            "admin-1",
+            "1",
             Instant.now()
         );
         when(consultantApprovalService.approveOrRejectConsultant(eq(1001L), any())).thenReturn(response);
+        Admin admin = new Admin();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
 
-        String body = "{\"adminId\":\"admin-1\",\"decision\":\"APPROVE\",\"reason\":\"ok\"}";
+        String body = "{\"adminId\":\"1\",\"decision\":\"APPROVE\",\"reason\":\"ok\"}";
 
         mockMvc.perform(post("/api/admin/consultants/1001/approval")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -71,8 +79,10 @@ class AdminControllerTest {
     void reapproveConsultant_conflict() throws Exception {
         when(consultantApprovalService.approveOrRejectConsultant(eq(1001L), any()))
             .thenThrow(new ConflictException("Consultant registration already decided"));
+        Admin admin = new Admin();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
 
-        String body = "{\"adminId\":\"admin-1\",\"decision\":\"APPROVE\",\"reason\":\"\"}";
+        String body = "{\"adminId\":\"1\",\"decision\":\"APPROVE\",\"reason\":\"\"}";
 
         mockMvc.perform(post("/api/admin/consultants/1001/approval")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -110,7 +120,7 @@ class AdminControllerTest {
 
     @Test
     void missingDecision_validationError400() throws Exception {
-        String body = "{\"adminId\":\"admin-1\"}";
+        String body = "{\"adminId\":\"1\"}";
 
         mockMvc.perform(post("/api/admin/consultants/1001/approval")
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Validate that the requester is an Admin before approving/rejecting consultant registrations: parse adminId, look up UserRepository and ensure the user is an Admin, otherwise return 403. Injected UserRepository into AdminController and added related imports and exception handling. Expanded ConsultantServiceImpl permission check to allow either Admin or Consultant to create consulting services and updated error messages. Updated integration and unit tests to create/mock Admin users and use numeric adminId values. Minor formatting fixes in DTO classes.