### PR TITLE
Rename payment success notification method

### DIFF
--- a/backend/src/main/java/com/consultingplatform/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/consultingplatform/notification/service/NotificationService.java
@@ -70,7 +70,7 @@ public class NotificationService {
         notificationRepository.save(clientNotification);
     }
 
-    public void sendPaymentSuccessNotifications(Booking booking) {
+    public void sendPaymentSuccessNotification(Booking booking) {
         if (!isNotificationSystemEnabled()) {
             return;
         }


### PR DESCRIPTION
Rename sendPaymentSuccessNotifications to sendPaymentSuccessNotification in NotificationService to reflect that it handles a single Booking. This is a refactor-only change to improve naming clarity; no behavior or logic was altered.